### PR TITLE
Added Soft reboot string and updated a translation

### DIFF
--- a/core/res/res/values-de/liquid_strings.xml
+++ b/core/res/res/values-de/liquid_strings.xml
@@ -26,7 +26,8 @@
   <string name="reboot_system" product="default">Telefon neustarten</string>
   <string name="global_action_screenshot">Screenshot</string>
   <string name="reboot_reboot">Neustart</string>
-  <string name="reboot_recovery">Wiederherstellung</string>
+  <string name="reboot_recovery">Recovery</string>
+  <string name="reboot_soft">Soft-Reboot</string>
   <string name="reboot_bootloader">Bootloader</string>
   <string name="reboot_bootmenu">Bootmenü</string>
   <string name="reboot_fastboot">Fastboot</string>

--- a/core/res/res/values/liquid_strings.xml
+++ b/core/res/res/values/liquid_strings.xml
@@ -47,6 +47,7 @@
     <string name="reboot_fastboot">Fastboot</string>
     <!-- Button to reboot the phone into download, within the Reboot Options dialog -->
     <string name="reboot_download">Download</string>
+    <string name="reboot_soft">Soft reboot</string>
 
     <!-- Reboot Progress Dialog. This is shown if the user chooses to reboot the phone. -->
     <string name="reboot_progress">Rebooting\u2026</string>


### PR DESCRIPTION
Soft reboot string is needed by recent changes to samsung_qcom-common by CyanogenMod. Otherwise there will be a build error
