### PR TITLE
Fix build for Contacts and PhoneCommon

### DIFF
--- a/core/res/res/values/colors.xml
+++ b/core/res/res/values/colors.xml
@@ -166,4 +166,8 @@
 -->
     <color name="trds_background">#ff000000</color>
     <color name="trds_text">#ffffffff</color>
+    
+    <--! Materialise color -->
+    <color name="material_blue_grey">#ff1b1f23</color>
+    <drawable name="material_bg_blue_grey">@color/material_blue_grey</drawable>
 </resources>


### PR DESCRIPTION
Fix this :

packages/apps/Contacts/../PhoneCommon/res/values/colors.xml:21: error: Error: No resource found that matches the given name (at 'background_dialpad' with value '@*android:color/material_blue_grey').

packages/apps/Contacts/res/values/colors.xml:47: error: Error: No resource found that matches the given name (at 'expanding_entry_card_background_color' with value '@*android:color/material_blue_grey').

packages/apps/Contacts/res/values/colors.xml:50: error: Error: No resource found that matches the given name (at 'card_margin_color' with value '@*android:color/material_blue_grey').

packages/apps/Contacts/res/values/styles.xml:55: error: Error: No resource found that matches the given name (at 'android:colorBackground' with value '@*android:drawable/material_bg_blue_grey').

packages/apps/Contacts/res/values/styles.xml:55: error: Error: No resource found that matches the given name (at 'android:colorBackground' with value '@*android:drawable/material_bg_blue_grey').
